### PR TITLE
Fix: Support API views instantiated without a request

### DIFF
--- a/rest_framework_serializer_extensions/views.py
+++ b/rest_framework_serializer_extensions/views.py
@@ -32,6 +32,11 @@ class SerializerExtensionsAPIViewMixin(object):
         through query parameters, or by the view.
         """
         context = dict()
+
+        # Request is unset during API client discovery
+        if self.request is None:
+            return context
+
         params_enabled = self.get_extensions_query_params_enabled()
 
         for field in ['expand', 'expand_id_only', 'exclude', 'only']:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -210,6 +210,10 @@ class GetSerializerContextTests(CBVTestCase):
             )
         )
 
+    def test_returns_empty_dict_when_no_request(self):
+        self.request = None
+        self.assertContextEquals(APITestView, dict())
+
 
 class SerializerExtensionsAPIViewMixinTests(TestCase):
     """


### PR DESCRIPTION
* This is done when the
[JS API client](http://www.django-rest-framework.org/topics/api-
clients/#javascript-client-library)
requests the endpoint details from the server
* Fixes #9 