### PR TITLE
Explicit decoding of README from UTF-8 in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def get_long_description():
     try:
         import pypandoc
     except ImportError:
-        return open('README.md').read()
+        return open('README.md', encoding='utf-8').read()
     else:
         return pypandoc.convert('README.md', 'rst')
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,10 @@ def get_long_description():
     try:
         import pypandoc
     except ImportError:
-        return open('README.md', encoding='utf-8').read()
+        if sys.version_info.major < 3:
+            return open('README.md').read()
+        else:
+            return open('README.md', encoding='utf-8').read()
     else:
         return pypandoc.convert('README.md', 'rst')
 


### PR DESCRIPTION
This fixes an issue I have installing this page using Python 3.5 and without (py)pandoc.


```
    Traceback (most recent call last):
      File "/tmp/pip-9otzkogk-build/setup.py", line 60, in get_long_description
        import pypandoc
    ImportError: No module named 'pypandoc'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-9otzkogk-build/setup.py", line 88, in <module>
        long_description=get_long_description(),
      File "/tmp/pip-9otzkogk-build/setup.py", line 62, in get_long_description
        return open('README.md').read()
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3631: ordinal not in range(128)
```