### PR TITLE
Update dependency & Django version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,54 +1,20 @@
 language: python
 
 python:
+    - "2.7"
     - "3.5"
+    - "3.6"
 
 sudo: false
-
-env:
-    - TOX_ENV=py27-flake8
-    - TOX_ENV=py27-docs
-    - TOX_ENV=py27-django18-drf33
-    - TOX_ENV=py27-django18-drf34
-    - TOX_ENV=py27-django18-drf35
-    - TOX_ENV=py27-django19-drf33
-    - TOX_ENV=py27-django19-drf34
-    - TOX_ENV=py27-django19-drf35
-    - TOX_ENV=py27-django110-drf33
-    - TOX_ENV=py27-django110-drf34
-    - TOX_ENV=py27-django110-drf35
-    - TOX_ENV=py34-django18-drf33
-    - TOX_ENV=py34-django18-drf34
-    - TOX_ENV=py34-django18-drf35
-    - TOX_ENV=py34-django19-drf33
-    - TOX_ENV=py34-django19-drf34
-    - TOX_ENV=py34-django19-drf35
-    - TOX_ENV=py34-django110-drf33
-    - TOX_ENV=py34-django110-drf34
-    - TOX_ENV=py34-django110-drf35
-    - TOX_ENV=py35-django18-drf33
-    - TOX_ENV=py35-django18-drf34
-    - TOX_ENV=py35-django18-drf35
-    - TOX_ENV=py35-django19-drf33
-    - TOX_ENV=py35-django19-drf34
-    - TOX_ENV=py35-django19-drf35
-    - TOX_ENV=py35-django110-drf33
-    - TOX_ENV=py35-django110-drf34
-    - TOX_ENV=py35-django110-drf35
 
 matrix:
     fast_finish: true
 
 install:
-    # Virtualenv < 14 is required to keep the Python 3.2 builds running.
-    - pip install tox "virtualenv<14"
+    pip install tox-travis
 
 script:
-    - tox -e $TOX_ENV
-
-after_success:
-    - pip install codecov
-    - codecov -e TOX_ENV
+    - tox
 
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ API, we suggest you consider switching to HashIds instead.
 **:star: Lovingly open-sourced by [Housekeep](https://housekeep.com).**
 
 ## Requirements
-* Python (2.7, 3.4, 3.5)
-* [Django](https://github.com/django/django) (1.8, 1.9, 1.10)
-* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.3, 3.4, 3.5)
+Tested against:
+
+* Python (2.7, 3.5, 3.6)
+* [Django](https://github.com/django/django) (1.8, 1.11, 2.0)
+* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.5, 3.6, 3.7)
 * [HashIds](https://github.com/davidaurelio/hashids-python) (>1.0)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # Minimum Django and REST framework version
-Django>=1.6
-djangorestframework>=2.4.3
+Django>=1.8
+djangorestframework>=3.5.4
 
 # Test requirements
 pytest-django==3.1.2
 pytest==3.0.5
 pytest-cov==2.4.0
 flake8==3.2.1
-django-test-plus==1.0.16
+django-test-plus==1.0.21
 
 # App requirements
 hashids==1.1.0

--- a/tests/models.py
+++ b/tests/models.py
@@ -5,7 +5,8 @@ class Owner(models.Model):
     name = models.CharField(max_length=32)
     email = models.EmailField(unique=True)
     organization = models.ForeignKey(
-        'tests.Organization', related_name='staff'
+        'tests.Organization', related_name='staff',
+        on_delete=models.CASCADE
     )
 
 
@@ -15,7 +16,9 @@ class Organization(models.Model):
 
 class Sku(models.Model):
     variant = models.CharField(max_length=32)
-    model = models.ForeignKey('tests.CarModel', related_name='skus')
+    model = models.ForeignKey(
+        'tests.CarModel', related_name='skus', on_delete=models.CASCADE
+    )
     owners = models.ManyToManyField('tests.Owner', related_name='cars')
 
     class Meta:
@@ -26,7 +29,7 @@ class Sku(models.Model):
 class CarModel(models.Model):
     name = models.CharField(max_length=32)
     manufacturer = models.ForeignKey(
-        'tests.Manufacturer', related_name='models'
+        'tests.Manufacturer', related_name='models', on_delete=models.CASCADE
     )
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import
 
-from django.core.urlresolvers import reverse
+# Django 1 vs. 2
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
+
 from django.test import override_settings, RequestFactory, TestCase
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import Serializer, ModelSerializer

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,22 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py34,py35}-django{18,19,110}-drf{33,34,35}
+       {py27,py35,py36}-django18-drf{35,36}
+       {py27,py35,py36}-django111-drf{35,36,37},
+       {py35,py36}-django20-drf37
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --coverage
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django18: Django==1.8.17
-       django19: Django==1.9.12
-       django110: Django==1.10.4
-       drf33: djangorestframework==3.3.3
-       drf34: djangorestframework==3.4.7
-       drf35: djangorestframework==3.5.3
-       django-test-plus==1.0.16
+       django18: Django==1.8.18
+       django111: Django==1.11.8
+       django20: Django==2.0.0
+       drf35: djangorestframework==3.5.4
+       drf36: djangorestframework==3.6.4
+       drf37: djangorestframework==3.7.7
+       django-test-plus==1.0.21
        pytest==3.0.5
        pytest-django==3.1.2
        pytest-cov==2.4.0


### PR DESCRIPTION
* In line with current Django version support: `1.8LTS, 1.11LTS, 2.0`
* Bumps Rest Framework to `current-2`
* Bumps Python 3 to 3.5 and 3.6
* See #6