### PR TITLE
Fix: Re-instate codecov coverage reporting 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cache
 .coverage
+.project
 .tox
 build
 dist

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       py27-{flake8,docs},
+       py36-{flake8,codecov,docs},
        {py27,py35,py36}-django18-drf{35,36}
        {py27,py35,py36}-django111-drf{35,36,37},
        {py35,py36}-django20-drf37
@@ -23,13 +23,23 @@ deps =
        hashids==1.1.0
        mock==2.0.0
 
-[testenv:py27-flake8]
+[testenv:py36-flake8]
 commands = ./runtests.py --lintonly
 deps =
        pytest==3.0.5
        flake8==3.2.1
 
-[testenv:py27-docs]
+[testenv:py36-codecov]
+commands =
+       {[testenv]commands}  # Run the tests and generate coverage report
+       codecov -e TOX_ENV   # Post coverage stats to codecov.io
+deps =
+       {[testenv]deps}
+       Django==2.0.0
+       djangorestframework==3.7.7
+       codecov==2.0.15
+
+[testenv:py36-docs]
 commands = mkdocs build
 deps =
        mkdocs>=0.16.1

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@ envlist =
        {py35,py36}-django20-drf37
 
 [testenv]
-commands = ./runtests.py --fast {posargs} --coverage
+passenv = CI TRAVIS TRAVIS_*
 setenv =
        PYTHONDONTWRITEBYTECODE=1
+commands = ./runtests.py --fast {posargs} --coverage
 deps =
        django18: Django==1.8.18
        django111: Django==1.11.8


### PR DESCRIPTION
* Codecov.io coverage reporting was dropped when moving to `tox-travis` to do CI builds
* This adds an additional tox environment in which to re-run the tests and the report the coverage stats
* Also bumps the "task" environments (e.g. flake8, docs) to run in Python 3 (I hear Python 2 is being dropped at some point... 😅 )