### PR TITLE
fix: Retain ordering when using exclude/only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+* Using the `order` or `excludes` keywords retains the original field ordering
+
 ### 0.6.0 (2018-07--02)
 * Adds the ability to automatically optimize the queryset used to generate
   the response. This feature is disabled by default, and is experimental

--- a/rest_framework_serializer_extensions/serializers.py
+++ b/rest_framework_serializer_extensions/serializers.py
@@ -737,11 +737,11 @@ class OnlyFieldsMixin(object):
                 )
             )
 
-        return {
-            name: field
+        return OrderedDict(
+            (name, field)
             for name, field in six.iteritems(fields)
             if name in only_names
-        }
+        )
 
 
 class ExcludeFieldsMixin(object):
@@ -777,11 +777,11 @@ class ExcludeFieldsMixin(object):
                 )
             )
 
-        return {
-            name: field
+        return OrderedDict(
+            (name, field)
             for name, field in six.iteritems(fields)
             if name not in exclude_names
-        }
+        )
 
 
 class SerializerHelpersMixin(object):

--- a/tests/test_serializers__exclude_fields_mixin.py
+++ b/tests/test_serializers__exclude_fields_mixin.py
@@ -172,3 +172,23 @@ class ExcludeFieldsSerializerMixinTests(SerializerMixinTestCase):
     def test_missing_child_key_many(self):
         with self.assertRaises(ValueError):
             self.serialize(exclude={'skus__not_found'})
+
+    def test_field_ordering_unchanged_root(self):
+        root_1 = self.serialize(exclude=('id', 'manufacturer'))
+        root_2 = self.serialize(exclude=('manufacturer', 'id'))
+
+        # The other of the fields is the same despite the `exclude` ordering
+        self.assertEqual(root_1.keys(), root_2.keys())
+
+        # And that order matches the serializer field ordering
+        self.assertListEqual(root_1.keys(), ['name', 'skus'])
+
+    def test_field_ordering_unchanged_nested(self):
+        child_1 = self.serialize(exclude=('skus__variant',))
+        child_2 = self.serialize(exclude=('skus__owners',))
+
+        keys_1 = child_1['skus'][0].keys()
+        self.assertListEqual(keys_1, ['id', 'owners'])
+
+        keys_2 = child_2['skus'][0].keys()
+        self.assertListEqual(keys_2, ['id', 'variant'])

--- a/tests/test_serializers__only_fields_mixin.py
+++ b/tests/test_serializers__only_fields_mixin.py
@@ -230,3 +230,23 @@ class OnlyFieldsSerializerMixinTests(SerializerMixinTestCase):
     def test_error_serialize_all_and_specific(self):
         with self.assertRaises(ValueError):
             self.serialize(only={'manufacturer', 'manufacturer__name'})
+
+    def test_field_ordering_unchanged_root(self):
+        root_1 = self.serialize(only=('name', 'id', 'manufacturer'))
+        root_2 = self.serialize(only=('manufacturer', 'id', 'name'))
+
+        # The other of the fields is the same despite the `only` ordering
+        self.assertEqual(root_1.keys(), root_2.keys())
+
+        # And that order matches the serializer field ordering
+        self.assertListEqual(root_1.keys(), ['id', 'name', 'manufacturer'])
+
+    def test_field_ordering_unchanged_nested(self):
+        child_1 = self.serialize(only=('skus__variant', 'skus__owners'))
+        child_2 = self.serialize(only=('skus__owners', 'skus__variant'))
+
+        keys_1 = child_1['skus'][0].keys()
+        keys_2 = child_2['skus'][0].keys()
+
+        self.assertEqual(keys_1, keys_2)
+        self.assertListEqual(keys_1, ['variant', 'owners'])


### PR DESCRIPTION
* Field filtering via either `only` or `exclude` (specifically, the mixins which drive them) retains the original ordering of the fields, by switching to using an `OrderedDict`
* This means that `get_field()` calls on serializer instances have a consistent API

Fixes #3 