### PR TITLE
Fix: Python3 test failures (dict keys not a list)

### DIFF
--- a/tests/test_serializers__exclude_fields_mixin.py
+++ b/tests/test_serializers__exclude_fields_mixin.py
@@ -181,14 +181,14 @@ class ExcludeFieldsSerializerMixinTests(SerializerMixinTestCase):
         self.assertEqual(root_1.keys(), root_2.keys())
 
         # And that order matches the serializer field ordering
-        self.assertListEqual(root_1.keys(), ['name', 'skus'])
+        self.assertEqual(list(root_1.keys()), ['name', 'skus'])
 
     def test_field_ordering_unchanged_nested(self):
         child_1 = self.serialize(exclude=('skus__variant',))
         child_2 = self.serialize(exclude=('skus__owners',))
 
         keys_1 = child_1['skus'][0].keys()
-        self.assertListEqual(keys_1, ['id', 'owners'])
+        self.assertEqual(list(keys_1), ['id', 'owners'])
 
         keys_2 = child_2['skus'][0].keys()
-        self.assertListEqual(keys_2, ['id', 'variant'])
+        self.assertEqual(list(keys_2), ['id', 'variant'])

--- a/tests/test_serializers__only_fields_mixin.py
+++ b/tests/test_serializers__only_fields_mixin.py
@@ -239,7 +239,7 @@ class OnlyFieldsSerializerMixinTests(SerializerMixinTestCase):
         self.assertEqual(root_1.keys(), root_2.keys())
 
         # And that order matches the serializer field ordering
-        self.assertListEqual(root_1.keys(), ['id', 'name', 'manufacturer'])
+        self.assertEqual(list(root_1.keys()), ['id', 'name', 'manufacturer'])
 
     def test_field_ordering_unchanged_nested(self):
         child_1 = self.serialize(only=('skus__variant', 'skus__owners'))
@@ -249,4 +249,4 @@ class OnlyFieldsSerializerMixinTests(SerializerMixinTestCase):
         keys_2 = child_2['skus'][0].keys()
 
         self.assertEqual(keys_1, keys_2)
-        self.assertListEqual(keys_1, ['variant', 'owners'])
+        self.assertEqual(list(keys_1), ['variant', 'owners'])


### PR DESCRIPTION
* I jumped the gun and merged #29 before the build had finished
* Forgot that Python3's `dict.keys()` doesn't return a list
* Will update Github to block merge until builds complete