### PR TITLE
Bump: Compliance with updated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 
 python:
     - "2.7"
-    - "3.5"
     - "3.6"
+    - "3.7"
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ API, we suggest you consider switching to HashIds instead.
 ## Requirements
 Tested against:
 
-* Python (2.7, 3.5, 3.6)
-* [Django](https://github.com/django/django) (1.8, 1.11, 2.0)
-* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.5, 3.6, 3.7)
+* Python (2.7, 3.6, 3.7)
+* [Django](https://github.com/django/django) (1.11, 2.1, 2.2)
+* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.7, 3.8, 3.9)
 * [HashIds](https://github.com/davidaurelio/hashids-python) (>1.0)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Minimum Django and REST framework version
-Django>=1.8
-djangorestframework>=3.5.4
+Django>=1.11
+djangorestframework>=3.7.7
 
 # Test requirements
 pytest-django==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ Django>=1.11
 djangorestframework>=3.7.7
 
 # Test requirements
-pytest-django==3.1.2
-pytest==3.0.5
-pytest-cov==2.4.0
-flake8==3.2.1
-django-test-plus==1.0.21
+pytest-django==3.4.8
+pytest==4.4.1
+pytest-cov==2.6.1
+flake8==3.7.7
+django-test-plus==1.1.1
 mock==2.0.0
 
 # App requirements

--- a/runtests.py
+++ b/runtests.py
@@ -12,7 +12,11 @@ PYTEST_ARGS = {
     'fast': ['tests', '-q'],
 }
 
-FLAKE8_ARGS = ['rest_framework_serializer_extensions', 'tests', '--ignore=E501']
+FLAKE8_ARGS = [
+    'rest_framework_serializer_extensions',
+    'tests',
+    '--ignore=E501,W504',
+]
 
 
 sys.path.append(os.path.dirname(__file__))

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
-       py36-{flake8,codecov,docs},
-       {py27,py35,py36}-django18-drf{35,36}
-       {py27,py35,py36}-django111-drf{35,36,37},
-       {py35,py36}-django20-drf37
+       py37-{flake8,codecov,docs},
+       {py27,py36,py37}-django111-drf{37,38,39},
+       {py36,py37}-django{21,22}-drf{37,38,39}
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
@@ -11,12 +10,12 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 commands = ./runtests.py --fast {posargs} --coverage
 deps =
-       django18: Django==1.8.18
        django111: Django==1.11.8
-       django20: Django==2.0.0
-       drf35: djangorestframework==3.5.4
-       drf36: djangorestframework==3.6.4
+       django21: Django==2.1.8
+       django22: Django==2.2.0
        drf37: djangorestframework==3.7.7
+       drf38: djangorestframework==3.8.2
+       drf39: djangorestframework==3.9.2
        django-test-plus==1.0.21
        pytest==3.0.5
        pytest-django==3.1.2
@@ -24,23 +23,23 @@ deps =
        hashids==1.1.0
        mock==2.0.0
 
-[testenv:py36-flake8]
+[testenv:py37-flake8]
 commands = ./runtests.py --lintonly
 deps =
        pytest==3.0.5
        flake8==3.2.1
 
-[testenv:py36-codecov]
+[testenv:py37-codecov]
 commands =
        {[testenv]commands}  # Run the tests and generate coverage report
        codecov -e TOX_ENV   # Post coverage stats to codecov.io
 deps =
        {[testenv]deps}
-       Django==2.0.0
-       djangorestframework==3.7.7
+       Django==2.2.0
+       djangorestframework==3.9.2
        codecov==2.0.15
 
-[testenv:py36-docs]
+[testenv:py37-docs]
 commands = mkdocs build
 deps =
        mkdocs>=0.16.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py37-{flake8,codecov,docs},
-       {py27,py36,py37}-django111-drf{37,38,39},
+       {py27,py36}-django111-drf{37,38,39},
        {py36,py37}-django{21,22}-drf{37,38,39}
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,10 @@ deps =
        drf37: djangorestframework==3.7.7
        drf38: djangorestframework==3.8.2
        drf39: djangorestframework==3.9.2
-       django-test-plus==1.0.21
-       pytest==3.0.5
-       pytest-django==3.1.2
-       pytest-cov==2.4.0
+       django-test-plus==1.1.1
+       pytest==4.4.1
+       pytest-django==3.4.8
+       pytest-cov==2.6.1
        hashids==1.1.0
        mock==2.0.0
 
@@ -27,7 +27,7 @@ deps =
 commands = ./runtests.py --lintonly
 deps =
        pytest==3.0.5
-       flake8==3.2.1
+       flake8==3.7.7
 
 [testenv:py37-codecov]
 commands =


### PR DESCRIPTION
Updates the tested-against environments to maintain LATEST - 2 support. Specifically, now includes:

* Python 3.6 and 3.7
* Django 2.1 and 2.2
* DRF 3.8 and 3.9

Refs #26 