### PR TITLE
Refactor: Update test assertions to remove Py3 deprecation warnings

### DIFF
--- a/tests/test_auto_optimise.py
+++ b/tests/test_auto_optimise.py
@@ -151,7 +151,7 @@ class TestAutoOptimizedQueryset(CBVTestCase):
             view_class, optimize=False, **query_params
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self.query_counter.count, expected_unoptimized,
             (
                 "Expected {0} unoptimized queries, actually {1}."
@@ -159,7 +159,7 @@ class TestAutoOptimizedQueryset(CBVTestCase):
             )
         )
         response_optimized = self.get(view_class, **query_params)
-        self.assertEquals(
+        self.assertEqual(
             self.query_counter.count, expected_optimized,
             (
                 "Expected {0} optimized queries, actually {1}."
@@ -167,7 +167,7 @@ class TestAutoOptimizedQueryset(CBVTestCase):
             )
         )
 
-        self.assertEquals(
+        self.assertEqual(
             response_optimized.data,
             response_unoptimized.data,
             "Optimized and unoptimized serialized results differed."
@@ -189,7 +189,7 @@ class TestAutoOptimizedQueryset(CBVTestCase):
         view.extensions_auto_optimize = True
         queryset = view.get_queryset()
         mock_auto_optimize.assert_called_once()
-        self.assertEquals('optimized', queryset)
+        self.assertEqual('optimized', queryset)
 
     @patch.object(test_serializers.OwnerTestSerializer, 'auto_optimize')
     def test_method_enabled_auto_optimization(self, mock_auto_optimize):
@@ -201,7 +201,7 @@ class TestAutoOptimizedQueryset(CBVTestCase):
         view.get_extensions_auto_optimize = lambda: True
         queryset = view.get_queryset()
         mock_auto_optimize.assert_called_once()
-        self.assertEquals('optimized', queryset)
+        self.assertEqual('optimized', queryset)
 
     @override_settings(
         REST_FRAMEWORK=dict(
@@ -219,7 +219,7 @@ class TestAutoOptimizedQueryset(CBVTestCase):
         view = self.get_view_instance(test_views.OwnerAPITestView)
         queryset = view.get_queryset()
         mock_auto_optimize.assert_called_once()
-        self.assertEquals('optimized', queryset)
+        self.assertEqual('optimized', queryset)
 
     def test_no_expansion(self):
         self.assertNumQueries(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -7,6 +7,7 @@ except ImportError:
     from django.urls import reverse
 
 from django.test import override_settings, RequestFactory, TestCase
+from django.utils import six
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import Serializer, ModelSerializer
 
@@ -77,7 +78,7 @@ class HashIdFieldTests(BaseFieldsTestCase):
     Unit tests for the HashIdField
     """
     def test_representation_requires_model(self):
-        with self.assertRaisesRegexp(AssertionError, 'No "model"'):
+        with six.assertRaisesRegex(self, AssertionError, 'No "model"'):
             fields.HashIdField().to_representation(self.car_model.pk)
 
     def test_representation_explicit_model_object(self):
@@ -85,17 +86,17 @@ class HashIdFieldTests(BaseFieldsTestCase):
             fields.HashIdField(model=models.CarModel)
             .to_representation(self.car_model.pk)
         )
-        self.assertEquals(self.external_id(self.car_model), representation)
+        self.assertEqual(self.external_id(self.car_model), representation)
 
     def test_representation_explicit_model_reference(self):
         representation = (
             fields.HashIdField(model='tests.models.CarModel')
             .to_representation(self.car_model.pk)
         )
-        self.assertEquals(self.external_id(self.car_model), representation)
+        self.assertEqual(self.external_id(self.car_model), representation)
 
     def test_representation_explicit_invalid_model_reference(self):
-        with self.assertRaisesRegexp(AssertionError, 'not a Django model'):
+        with six.assertRaisesRegex(self, AssertionError, 'not a Django model'):
             (
                 fields.HashIdField(model='tests.base.TEST_HASH_IDS')
                 .to_representation(self.car_model.pk)
@@ -107,7 +108,7 @@ class HashIdFieldTests(BaseFieldsTestCase):
         """
         field = CarModelTestSerializer().fields['id']
         representation = field.to_representation(self.car_model.pk)
-        self.assertEquals(self.external_id(self.car_model), representation)
+        self.assertEqual(self.external_id(self.car_model), representation)
 
     def test_representation_explicit_model_serializer_method(self):
         """
@@ -115,10 +116,10 @@ class HashIdFieldTests(BaseFieldsTestCase):
         """
         field = CarModelMethodTestSerializer().fields['manufacturer_id']
         representation = field.to_representation(self.manufacturer.pk)
-        self.assertEquals(self.external_id(self.manufacturer), representation)
+        self.assertEqual(self.external_id(self.manufacturer), representation)
 
     def test_internal_value_requires_model(self):
-        with self.assertRaisesRegexp(AssertionError, 'No "model"'):
+        with six.assertRaisesRegex(self, AssertionError, 'No "model"'):
             fields.HashIdField().to_internal_value(
                 self.external_id(self.car_model)
             )
@@ -128,24 +129,26 @@ class HashIdFieldTests(BaseFieldsTestCase):
             fields.HashIdField(model=models.CarModel)
             .to_internal_value(self.external_id(self.car_model))
         )
-        self.assertEquals(self.car_model.pk, internal_value)
+        self.assertEqual(self.car_model.pk, internal_value)
 
     def test_internal_value_explicit_model_reference(self):
         internal_value = (
             fields.HashIdField(model='tests.models.CarModel')
             .to_internal_value(self.external_id(self.car_model))
         )
-        self.assertEquals(self.car_model.pk, internal_value)
+        self.assertEqual(self.car_model.pk, internal_value)
 
     def test_internal_value_explicit_invalid_model_reference(self):
-        with self.assertRaisesRegexp(AssertionError, 'not a Django model'):
+        with six.assertRaisesRegex(self, AssertionError, 'not a Django model'):
             (
                 fields.HashIdField(model='tests.base.TEST_HASH_IDS')
                 .to_internal_value(self.external_id(self.car_model))
             )
 
     def test_internal_value_hash_id_validation(self):
-        with self.assertRaisesRegexp(ValidationError, 'not a valid HashId'):
+        with six.assertRaisesRegex(
+            self, ValidationError, 'not a valid HashId'
+        ):
             (
                 fields.HashIdField(model='tests.models.CarModel')
                 .to_internal_value('abc123')
@@ -159,7 +162,7 @@ class HashIdFieldTests(BaseFieldsTestCase):
         internal_value = field.to_internal_value(
             self.external_id(self.car_model)
         )
-        self.assertEquals(self.car_model.pk, internal_value)
+        self.assertEqual(self.car_model.pk, internal_value)
 
     def test_internal_value_explicit_model_serializer_method(self):
         """
@@ -169,7 +172,7 @@ class HashIdFieldTests(BaseFieldsTestCase):
         internal_value = field.to_internal_value(
             self.external_id(self.manufacturer)
         )
-        self.assertEquals(self.manufacturer.pk, internal_value)
+        self.assertEqual(self.manufacturer.pk, internal_value)
 
 
 class HashIdHyperlinkedIdentityFieldTests(BaseFieldsTestCase):
@@ -208,7 +211,7 @@ class HashIdHyperlinkedIdentityFieldTests(BaseFieldsTestCase):
         expected_path = reverse(
             'car_model', args=(self.external_id(self.manufacturer),)
         )
-        self.assertEquals(
+        self.assertEqual(
             serialized['manufacturer'],
             'http://testserver{0}'.format(expected_path)
         )

--- a/tests/test_serializers__expandable_fields_mixin.py
+++ b/tests/test_serializers__expandable_fields_mixin.py
@@ -724,7 +724,7 @@ class ExpandableFieldsSerializerMixinTests(SerializerMixinTestCase):
             )
         )
         self.assertTrue(serializer.is_valid())
-        self.assertEquals(dict(name='Ka'), serializer.validated_data)
+        self.assertEqual(dict(name='Ka'), serializer.validated_data)
 
     def test_deserialize_writable_field(self):
         """
@@ -739,7 +739,7 @@ class ExpandableFieldsSerializerMixinTests(SerializerMixinTestCase):
             )
         )
         self.assertTrue(serializer.is_valid())
-        self.assertEquals(
+        self.assertEqual(
             dict(
                 name='Ka',
                 manufacturer_id=self.manufacturer_tesla.pk,

--- a/tests/test_serializers__helpers_mixin.py
+++ b/tests/test_serializers__helpers_mixin.py
@@ -100,22 +100,22 @@ class SerializerHelpersHierarchyTests(TestCase):
         self.fields = CarModelTestSerializer().fields
 
     def test_hierarchy_root(self):
-        self.assertEquals('', CarModelTestSerializer().hierarchy)
+        self.assertEqual('', CarModelTestSerializer().hierarchy)
 
     def test_child_serializer(self):
-        self.assertEquals(
+        self.assertEqual(
             'manufacturer',
             self.fields['manufacturer'].hierarchy
         )
 
     def test_many_child_serializer(self):
-        self.assertEquals(
+        self.assertEqual(
             'skus',
             self.fields['skus'].child.hierarchy
         )
 
     def test_nested_child_serializer(self):
-        self.assertEquals(
+        self.assertEqual(
             'skus__owners',
             self.fields['skus'].child.fields['owners'].child.hierarchy
         )
@@ -127,7 +127,7 @@ class SerializerHelpersHierarchyTests(TestCase):
             .child.fields['organization']
         )
 
-        self.assertEquals(
+        self.assertEqual(
             'skus__owners__organization',
             nested_serializer.hierarchy
         )
@@ -149,16 +149,16 @@ class RepresentChildTests(TestCase):
         self.serialized = self.serializer.data
 
     def test_hierarchy_maintained(self):
-        self.assertEquals('child', self.serialized['child']['hierarchy'])
+        self.assertEqual('child', self.serialized['child']['hierarchy'])
 
     def test_instance_passed(self):
-        self.assertEquals(
+        self.assertEqual(
             self.internal_value['child']['id'],
             self.serialized['child']['id']
         )
 
     def test_context_passed(self):
-        self.assertEquals(
+        self.assertEqual(
             self.context['label'],
             self.serialized['child']['context_label']
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings, TestCase
+from django.utils import six
 
 from rest_framework_serializer_extensions import fields, utils
 from test_package.test_module.serializers import TestSerializer
@@ -58,7 +59,7 @@ class GetSettingTests(TestCase):
         )
     )
     def test_extension_setting_exists(self):
-        self.assertEquals('bar', utils.get_setting('FOO'))
+        self.assertEqual('bar', utils.get_setting('FOO'))
 
     @override_settings(REST_FRAMEWORK=dict(SERIALIZER_EXTENSIONS=dict()))
     def test_extension_setting_does_not_exist(self):
@@ -70,7 +71,7 @@ class GetHashIdsSourceTests(TestCase):
     Unit tests for the get_hash_ids_source() utility method.
     """
     def test_unset_raises(self):
-        with self.assertRaisesRegexp(AssertionError, 'No HASH_IDS_SOURCE'):
+        with six.assertRaisesRegex(self, AssertionError, 'No HASH_IDS_SOURCE'):
             utils.get_hash_ids_source()
 
     @override_settings(
@@ -144,7 +145,7 @@ class InternalIdFromModelAndExternalIdTests(TestCase):
         org_b = models.Organization.objects.create(name='b')
 
         external_id_a = utils.get_hash_ids_source().encode(ct_org.pk, org_a.pk)
-        self.assertEquals(
+        self.assertEqual(
             org_a.pk,
             utils.internal_id_from_model_and_external_id(
                 models.Organization, external_id_a
@@ -152,7 +153,7 @@ class InternalIdFromModelAndExternalIdTests(TestCase):
         )
 
         external_id_b = utils.get_hash_ids_source().encode(ct_org.pk, org_b.pk)
-        self.assertEquals(
+        self.assertEqual(
             org_b.pk,
             utils.internal_id_from_model_and_external_id(
                 models.Organization, external_id_b
@@ -168,14 +169,14 @@ class ModelFromDefinitionTests(TestCase):
         """
         An error should be raised when a non-Django model class is passed.
         """
-        with self.assertRaisesRegexp(AssertionError, 'not a Django model'):
+        with six.assertRaisesRegex(self, AssertionError, 'not a Django model'):
             utils.model_from_definition(dict)
 
     def test_pass_string_as_model_definition(self):
         """
         Passing string corresponding to model should import and return model.
         """
-        self.assertEquals(
+        self.assertEqual(
             models.CarModel,
             utils.model_from_definition('tests.models.CarModel')
         )
@@ -184,6 +185,6 @@ class ModelFromDefinitionTests(TestCase):
         """
         Test that the method returns its argument when Django model is passed.
         """
-        self.assertEquals(
+        self.assertEqual(
             models.CarModel, utils.model_from_definition(models.CarModel)
         )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -273,8 +273,8 @@ class ExternalIdViewMixinTests(TestCase):
             test_models.Owner, self.owner.pk
         )
         response = self.get_response(external_id)
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(self.owner.pk, response.data['id'])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(self.owner.pk, response.data['id'])
 
     def test_raises_404_when_not_found(self):
         bad_external_id = (
@@ -283,4 +283,4 @@ class ExternalIdViewMixinTests(TestCase):
             )
         )
         response = self.get_response(bad_external_id)
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)


### PR DESCRIPTION
* Replaces `assertEquals` with `assertEqual`
* Has to use six's `assertRaisesRegex` due to py2/3 differences