### PR TITLE
Adding Django 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: xenial
 language: python
 
 python:
-    - "2.7"
     - "3.6"
     - "3.7"
+    - "3.8"
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ API, we suggest you consider switching to HashIds instead.
 ## Requirements
 Tested against:
 
-* Python (2.7, 3.6, 3.7, 3.8)
-* [Django](https://github.com/django/django) (1.11, 2.1, 2.2, 3.0)
-* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.7, 3.8, 3.9, 3.10)
+* Python (3.6, 3.7, 3.8)
+* [Django](https://github.com/django/django) (2.1, 2.2, 3.0)
+* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.8, 3.9, 3.10)
 * [HashIds](https://github.com/davidaurelio/hashids-python) (>1.0)
 
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ API, we suggest you consider switching to HashIds instead.
 ## Requirements
 Tested against:
 
-* Python (2.7, 3.6, 3.7)
-* [Django](https://github.com/django/django) (1.11, 2.1, 2.2)
-* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.7, 3.8, 3.9)
+* Python (2.7, 3.6, 3.7, 3.8)
+* [Django](https://github.com/django/django) (1.11, 2.1, 2.2, 3.0)
+* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.7, 3.8, 3.9, 3.10)
 * [HashIds](https://github.com/davidaurelio/hashids-python) (>1.0)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytest-django==3.4.8
 pytest==4.4.1
 pytest-cov==2.6.1
 flake8==3.7.7
-django-test-plus==1.1.1
+django-test-plus==1.4.0
 mock==2.0.0
 
 # App requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Minimum Django and REST framework version
-Django>=1.11
-djangorestframework>=3.7.7
+Django>=2.0
+djangorestframework>=3.8.2
 
 # Test requirements
 pytest-django==3.4.8

--- a/rest_framework_serializer_extensions/fields.py
+++ b/rest_framework_serializer_extensions/fields.py
@@ -1,5 +1,5 @@
+import six
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils import six
 from rest_framework.fields import Field
 from rest_framework.relations import (
     HyperlinkedIdentityField, HyperlinkedRelatedField)

--- a/rest_framework_serializer_extensions/fields.py
+++ b/rest_framework_serializer_extensions/fields.py
@@ -1,4 +1,3 @@
-import six
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.fields import Field
 from rest_framework.relations import (
@@ -37,7 +36,7 @@ class GetHashIdModelMixin(object):
                         'No "model" value passed to field "{0}"'
                         .format(type(self).__name__)
                     )
-        elif isinstance(self.model, six.string_types):
+        elif isinstance(self.model, str):
             return utils.model_from_definition(self.model)
         else:
             return self.model

--- a/rest_framework_serializer_extensions/serializers.py
+++ b/rest_framework_serializer_extensions/serializers.py
@@ -1,9 +1,6 @@
-from __future__ import absolute_import
-
 from collections import OrderedDict
 from pprint import pformat
 
-import six
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import Prefetch
 from django.db.models.fields.related import ForeignKey
@@ -336,7 +333,7 @@ class ExpandableFieldsMixin(object):
         """
         expand_fields = self._get_expand_fields()
 
-        for field_name, field in six.iteritems(expand_fields):
+        for field_name, field in expand_fields.items():
             if field_name.endswith('_id'):
                 field_definition = self.expandable_fields[field_name[:-3]]
             else:
@@ -416,7 +413,7 @@ class ExpandableFieldsMixin(object):
     def _standardise_expandable_definitions(self, expandable_fields):
         return {
             key: self._standardise_expandable_definition(definition)
-            for key, definition in six.iteritems(expandable_fields)
+            for key, definition in expandable_fields.items()
         }
 
     def _standardise_expandable_definition(self, definition):
@@ -427,7 +424,7 @@ class ExpandableFieldsMixin(object):
             definition = dict(serializer=definition)
 
         # Resolve string references to serializers
-        if isinstance(definition['serializer'], six.string_types):
+        if isinstance(definition['serializer'], str):
             reference = definition['serializer']
             serializer = utils.import_local(reference)
             assert issubclass(serializer, serializers.BaseSerializer), (
@@ -471,7 +468,7 @@ class ExpandableFieldsMixin(object):
     def _validate_max_depth(self, root_instructions):
         max_depth = self.get_max_expand_depth()
 
-        for nested_field_names in six.itervalues(root_instructions):
+        for nested_field_names in root_instructions.values():
             for nested_field_name in nested_field_names:
                 depth = len(nested_field_name.split(EXPAND_DELIMITER))
 
@@ -500,7 +497,7 @@ class ExpandableFieldsMixin(object):
         hierarchy = _get_serializer_hierarchy(self)
         instructions = {}
 
-        for method, root_nested_names in six.iteritems(root_instructions):
+        for method, root_nested_names in root_instructions.items():
             instructions[method] = {
                 n.split(EXPAND_DELIMITER)[0]
                 for n in _get_nested_field_names(hierarchy, root_nested_names)
@@ -592,7 +589,7 @@ class ExpandableFieldsMixin(object):
         ):
             return
 
-        for method, field_names in six.iteritems(instructions):
+        for method, field_names in instructions.items():
             valid_field_names = set(self.expandable_fields)
 
             # Allow unmatched full expand instructions provided that the
@@ -625,7 +622,7 @@ class ExpandableFieldsMixin(object):
         if standard_fields:
             self._validate_instructions(instructions, standard_fields)
 
-        field_iterator = six.iteritems(self.expandable_fields)
+        field_iterator = self.expandable_fields.items()
 
         # As we add <fieldname>_id fields for foreign keys, take note of any
         # that require translation to model instances in the case of an update
@@ -739,7 +736,7 @@ class OnlyFieldsMixin(object):
 
         return OrderedDict(
             (name, field)
-            for name, field in six.iteritems(fields)
+            for name, field in fields.items()
             if name in only_names
         )
 
@@ -779,7 +776,7 @@ class ExcludeFieldsMixin(object):
 
         return OrderedDict(
             (name, field)
-            for name, field in six.iteritems(fields)
+            for name, field in fields.items()
             if name not in exclude_names
         )
 

--- a/rest_framework_serializer_extensions/serializers.py
+++ b/rest_framework_serializer_extensions/serializers.py
@@ -12,6 +12,7 @@ from rest_framework_serializer_extensions import (
     fields as custom_fields, utils
 )
 
+
 SOURCE_DELIMITER = '.'
 QUERYSET_DELIMITER = '__'
 EXPAND_DELIMITER = '__'

--- a/rest_framework_serializer_extensions/serializers.py
+++ b/rest_framework_serializer_extensions/serializers.py
@@ -1,19 +1,19 @@
 from __future__ import absolute_import
+
 from collections import OrderedDict
 from pprint import pformat
 
+import six
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import Prefetch
 from django.db.models.fields.related import ForeignKey
 from django.db.models.query import QuerySet
-from django.utils import six
 from rest_framework import serializers
 from rest_framework.fields import empty
 
 from rest_framework_serializer_extensions import (
     fields as custom_fields, utils
 )
-
 
 SOURCE_DELIMITER = '.'
 QUERYSET_DELIMITER = '__'

--- a/rest_framework_serializer_extensions/utils.py
+++ b/rest_framework_serializer_extensions/utils.py
@@ -1,9 +1,9 @@
 import importlib
 
+import six
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.utils import six
 
 
 def import_local(path_to_object):

--- a/rest_framework_serializer_extensions/utils.py
+++ b/rest_framework_serializer_extensions/utils.py
@@ -1,6 +1,5 @@
 import importlib
 
-import six
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -93,7 +92,7 @@ def model_from_definition(model_definition):
     Returns:
         (django.db.models.Model)
     """
-    if isinstance(model_definition, six.string_types):
+    if isinstance(model_definition, str):
         model = import_local(model_definition)
     else:
         model = model_definition

--- a/runtests.py
+++ b/runtests.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-from __future__ import print_function
 
 import pytest
 import sys

--- a/setup.py
+++ b/setup.py
@@ -98,11 +98,10 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.test import TestCase
 from hashids import Hashids
 

--- a/tests/test_auto_optimise.py
+++ b/tests/test_auto_optimise.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import django
 from django.db import connection
 from django.http import QueryDict

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import six
+
 # Django 1 vs. 2
 try:
     from django.core.urlresolvers import reverse
@@ -7,7 +9,6 @@ except ImportError:
     from django.urls import reverse
 
 from django.test import override_settings, RequestFactory, TestCase
-from django.utils import six
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import Serializer, ModelSerializer
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,13 +1,4 @@
-from __future__ import absolute_import
-
-import six
-
-# Django 1 vs. 2
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
-
+from django.urls import reverse
 from django.test import override_settings, RequestFactory, TestCase
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import Serializer, ModelSerializer
@@ -79,7 +70,7 @@ class HashIdFieldTests(BaseFieldsTestCase):
     Unit tests for the HashIdField
     """
     def test_representation_requires_model(self):
-        with six.assertRaisesRegex(self, AssertionError, 'No "model"'):
+        with self.assertRaisesRegex(AssertionError, 'No "model"'):
             fields.HashIdField().to_representation(self.car_model.pk)
 
     def test_representation_explicit_model_object(self):
@@ -97,7 +88,7 @@ class HashIdFieldTests(BaseFieldsTestCase):
         self.assertEqual(self.external_id(self.car_model), representation)
 
     def test_representation_explicit_invalid_model_reference(self):
-        with six.assertRaisesRegex(self, AssertionError, 'not a Django model'):
+        with self.assertRaisesRegex(AssertionError, 'not a Django model'):
             (
                 fields.HashIdField(model='tests.base.TEST_HASH_IDS')
                 .to_representation(self.car_model.pk)
@@ -120,7 +111,7 @@ class HashIdFieldTests(BaseFieldsTestCase):
         self.assertEqual(self.external_id(self.manufacturer), representation)
 
     def test_internal_value_requires_model(self):
-        with six.assertRaisesRegex(self, AssertionError, 'No "model"'):
+        with self.assertRaisesRegex(AssertionError, 'No "model"'):
             fields.HashIdField().to_internal_value(
                 self.external_id(self.car_model)
             )
@@ -140,16 +131,14 @@ class HashIdFieldTests(BaseFieldsTestCase):
         self.assertEqual(self.car_model.pk, internal_value)
 
     def test_internal_value_explicit_invalid_model_reference(self):
-        with six.assertRaisesRegex(self, AssertionError, 'not a Django model'):
+        with self.assertRaisesRegex(AssertionError, 'not a Django model'):
             (
                 fields.HashIdField(model='tests.base.TEST_HASH_IDS')
                 .to_internal_value(self.external_id(self.car_model))
             )
 
     def test_internal_value_hash_id_validation(self):
-        with six.assertRaisesRegex(
-            self, ValidationError, 'not a valid HashId'
-        ):
+        with self.assertRaisesRegex(ValidationError, 'not a valid HashId'):
             (
                 fields.HashIdField(model='tests.models.CarModel')
                 .to_internal_value('abc123')

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,5 @@
-from django.urls import reverse
 from django.test import override_settings, RequestFactory, TestCase
+from django.urls import reverse
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import Serializer, ModelSerializer
 

--- a/tests/test_serializers__exclude_fields_mixin.py
+++ b/tests/test_serializers__exclude_fields_mixin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from rest_framework import serializers
 
 from rest_framework_serializer_extensions.serializers import ExcludeFieldsMixin

--- a/tests/test_serializers__expandable_fields_mixin.py
+++ b/tests/test_serializers__expandable_fields_mixin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.test import override_settings
 from rest_framework import serializers
 

--- a/tests/test_serializers__helpers_mixin.py
+++ b/tests/test_serializers__helpers_mixin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.test import TestCase
 from rest_framework import serializers
 

--- a/tests/test_serializers__only_fields_mixin.py
+++ b/tests/test_serializers__only_fields_mixin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from rest_framework import serializers
 
 from rest_framework_serializer_extensions.serializers import OnlyFieldsMixin

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-import six
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings, TestCase
 
@@ -71,7 +68,7 @@ class GetHashIdsSourceTests(TestCase):
     Unit tests for the get_hash_ids_source() utility method.
     """
     def test_unset_raises(self):
-        with six.assertRaisesRegex(self, AssertionError, 'No HASH_IDS_SOURCE'):
+        with self.assertRaisesRegex(AssertionError, 'No HASH_IDS_SOURCE'):
             utils.get_hash_ids_source()
 
     @override_settings(
@@ -169,7 +166,7 @@ class ModelFromDefinitionTests(TestCase):
         """
         An error should be raised when a non-Django model class is passed.
         """
-        with six.assertRaisesRegex(self, AssertionError, 'not a Django model'):
+        with self.assertRaisesRegex(AssertionError, 'not a Django model'):
             utils.model_from_definition(dict)
 
     def test_pass_string_as_model_definition(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
+import six
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings, TestCase
-from django.utils import six
 
 from rest_framework_serializer_extensions import fields, utils
 from test_package.test_module.serializers import TestSerializer

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.http import QueryDict
 from django.test import override_settings, RequestFactory, TestCase
 from mock import patch

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
        py38-{flake8,codecov,docs},
-       {py27,py36}-django111-drf{37,38,39},
-       {py36,py37,py38}-django{21,22}-drf{37,38,39,310}
+       {py36,py37,py38}-django{21,22}-drf{38,39,310}
        {py36,py37,py38}-django{30}-drf{310}
 
 [testenv]
@@ -11,11 +10,9 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 commands = ./runtests.py --fast {posargs} --coverage
 deps =
-       django111: Django==1.11.25
        django21: Django==2.1.15
        django22: Django==2.2.8
        django30: Django==3.0.0
-       drf37: djangorestframework==3.7.7
        drf38: djangorestframework==3.8.2
        drf39: djangorestframework==3.9.4
        drf310: djangorestframework==3.10.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
-       py37-{flake8,codecov,docs},
+       py38-{flake8,codecov,docs},
        {py27,py36}-django111-drf{37,38,39},
-       {py36,py37}-django{21,22}-drf{37,38,39}
+       {py36,py37,py38}-django{21,22}-drf{37,38,39,310}
+       {py36,py37,py38}-django{30}-drf{310}
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
@@ -10,36 +11,38 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 commands = ./runtests.py --fast {posargs} --coverage
 deps =
-       django111: Django==1.11.8
-       django21: Django==2.1.8
-       django22: Django==2.2.0
+       django111: Django==1.11.25
+       django21: Django==2.1.15
+       django22: Django==2.2.8
+       django30: Django==3.0.0
        drf37: djangorestframework==3.7.7
        drf38: djangorestframework==3.8.2
-       drf39: djangorestframework==3.9.2
-       django-test-plus==1.1.1
+       drf39: djangorestframework==3.9.4
+       drf310: djangorestframework==3.10.3
+       django-test-plus==1.4.0
        pytest==4.4.1
        pytest-django==3.4.8
        pytest-cov==2.6.1
        hashids==1.1.0
        mock==2.0.0
 
-[testenv:py37-flake8]
+[testenv:py38-flake8]
 commands = ./runtests.py --lintonly
 deps =
        pytest==3.0.5
        flake8==3.7.7
 
-[testenv:py37-codecov]
+[testenv:py38-codecov]
 commands =
        {[testenv]commands}  # Run the tests and generate coverage report
        codecov -e TOX_ENV   # Post coverage stats to codecov.io
 deps =
        {[testenv]deps}
-       Django==2.2.0
-       djangorestframework==3.9.2
+       Django==3.0.0
+       djangorestframework==3.10.3
        codecov==2.0.15
 
-[testenv:py37-docs]
+[testenv:py38-docs]
 commands = mkdocs build
 deps =
        mkdocs>=0.16.1


### PR DESCRIPTION
- drops Python 2 support
- updates tox to newer Python/Django/DRF versions
- updates django-test-plus for Django 3.0 support
- updates docs for newly-supported versions

Resolves #34 