### PR TITLE
Add Django REST Framework 3.11 to tox.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Tested against:
 
 * Python (3.6, 3.7, 3.8)
 * [Django](https://github.com/django/django) (2.1, 2.2, 3.0)
-* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.8, 3.9, 3.10)
+* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.8, 3.9, 3.10, 3.11)
 * [HashIds](https://github.com/davidaurelio/hashids-python) (>1.0)
 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Tested against:
 
 * Python (3.6, 3.7, 3.8)
 * [Django](https://github.com/django/django) (2.1, 2.2, 3.0)
-* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.8, 3.9, 3.10, 3.11)
+* [Django REST Framework](https://github.com/tomchristie/django-rest-framework) (3.9, 3.10, 3.11)
 * [HashIds](https://github.com/davidaurelio/hashids-python) (>1.0)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Minimum Django and REST framework version
 Django>=2.0
-djangorestframework>=3.8.2
+djangorestframework>=3.9.4
 
 # Test requirements
 pytest-django==3.4.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
        py38-{flake8,codecov,docs},
-       {py36,py37,py38}-django{21,22}-drf{38,39,310}
-       {py36,py37,py38}-django{30}-drf{310}
+       {py36,py37,py38}-django{21,22}-drf{38,39,310,311}
+       {py36,py37,py38}-django{30}-drf{310,311}
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
@@ -16,6 +16,7 @@ deps =
        drf38: djangorestframework==3.8.2
        drf39: djangorestframework==3.9.4
        drf310: djangorestframework==3.10.3
+       drf311: djangorestframework==3.11.0
        django-test-plus==1.4.0
        pytest==4.4.1
        pytest-django==3.4.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py38-{flake8,codecov,docs},
-       {py36,py37,py38}-django{21,22}-drf{38,39,310,311}
+       {py36,py37,py38}-django{21,22}-drf{39,310,311}
        {py36,py37,py38}-django{30}-drf{310,311}
 
 [testenv]
@@ -13,7 +13,6 @@ deps =
        django21: Django==2.1.15
        django22: Django==2.2.8
        django30: Django==3.0.0
-       drf38: djangorestframework==3.8.2
        drf39: djangorestframework==3.9.4
        drf310: djangorestframework==3.10.3
        drf311: djangorestframework==3.11.0


### PR DESCRIPTION
3.11 was [released](https://www.django-rest-framework.org/community/3.11-announcement/) with support for Django 3.0.