### PR TITLE
Update CI to test against current Python/Django/DRF

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-* Support for Python 3.9, 3.10, 3.11, and 3.12
-* Support for Django 3.2, 4.2, and 5.0
-* Support for Django REST Framework 3.12, 3.13, 3.14, and 3.15
+* Support for Python 3.10, 3.11, 3.12, 3.13, and 3.14
+* Support for Django 4.2, 5.2, and 6.0
+* Support for Django REST Framework 3.15 and 3.16
 
 ### Changed
 * Switches from Travis CI to Github Actions
@@ -18,9 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Drops `mock` dependency, in favour of `unittest.mock`
 
 ### Removed
-* Support for Python <= 3.7 (EOL 2023)
-* Support for Django <= 3.1 (EOL 2021)
-* Support for Django REST Framework <= 3.11
+* Support for Python <= 3.9 (EOL 2025)
+* Support for Django <= 4.1 (EOL 2023)
+* Support for Django REST Framework <= 3.14
 
 ## [2.0.1] - 2020-09-20
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ API, we suggest you consider switching to HashIds instead.
 ## Requirements
 Tested against:
 
-* Python (3.8, 3.9, 3.10, 3.11, 3.12)
-* [Django](https://github.com/django/django) (3.2, 4.2, 5.0)
+* Python (3.10, 3.11, 3.12, 3.13, 3.14)
+* [Django](https://github.com/django/django) (4.2, 5.2, 6.0)
 * [Django REST Framework](https://github.com/tomchristie/django-rest-framework) 
-  (3.12, 3.13, 3.14, 3.15). Note Django REST Framework 3.15 is the first version to
-  officially support Django 4.2+.
+  (3.15, 3.16). Note Django REST Framework 3.16.1 is the first version to
+  officially support Django 5.2+.
 * [HashIds](https://github.com/davidaurelio/hashids-python) (>1.0)
 
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,9 +11,9 @@ API, we suggest you consider switching to HashIDs instead.
 
 
 ## Requirements
-* Python (3.8, 3.9, 3.10, 3.11, 3.12)
-* [Django](https://github.com/django/django) (3.2, 4.2, 5.0)
+* Python (3.10, 3.11, 3.12, 3.13, 3.14)
+* [Django](https://github.com/django/django) (4.2, 5.2, 6.0)
 * [Django REST Framework](https://github.com/tomchristie/django-rest-framework) 
-  (3.12, 3.13, 3.14, 3.15). Note Django REST Framework 3.15 is the first version to
-  officially support Django 4.2+.
+  (3.15, 3.16). Note Django REST Framework 3.16.1 is the first version to
+  officially support Django 5.2+.
 * [HashIds](https://github.com/davidaurelio/hashids-python) (>1.0)

--- a/requirements-coverage.txt
+++ b/requirements-coverage.txt
@@ -2,4 +2,4 @@
 # Note: These packages are stored outside of the setup.py, to maintain a
 # single source of truth, and allow the extras to be installed in isolation.
 codecov==2.1.13
-pytest-cov==4.1.0
+pytest-cov==7.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Development / CI requirements
 # Note: These packages are stored outside of the setup.py, to maintain a
 # single source of truth, and allow the extras to be installed in isolation.
-black==24.2.0
-flake8==7.0.0
-isort==5.13.2
-wheel==0.42.0  # for PyPI installs
+black==26.1.0
+flake8==7.3.0
+isort==8.0.1
+wheel==0.46.3  # for PyPI installs

--- a/requirements-mkdocs.txt
+++ b/requirements-mkdocs.txt
@@ -1,1 +1,1 @@
-mkdocs==1.5.3  # for documentation previews/deploys
+mkdocs==1.6.1  # for documentation previews/deploys

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,10 +1,10 @@
 # Test requirements
 # Note: These packages are stored outside of the setup.py, to maintain a
 # single source of truth, and allow the extras to be installed in isolation.
-django-test-plus==1.4.0
-Django>=3.2,<5.1
-djangorestframework>=3.12
-pytest-cov==4.1.0
-pytest-django==4.8.0
-pytest==8.0.0
-setuptools==69.1.0
+django-test-plus==2.4.1
+Django>=4.2,<6.1
+djangorestframework>=3.15
+pytest-cov==7.0.0
+pytest-django==4.12.0
+pytest==9.0.2
+setuptools==82.0.0

--- a/setup.py
+++ b/setup.py
@@ -126,11 +126,11 @@ setup(
         "Operating System :: OS Independent",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Internet :: WWW/HTTP",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,30 +4,28 @@ envlist =
     flake8
     codecov
     docs
-    {py38,py39}-django{32}-drf{312,313,314,315}
-    {py38,py39,py310,py311,py312}-django{42}-drf{314,315}
-    {py310,py311,py312}-django{50}-drf{314,315}
+    {py310,py311,py312}-django{42}-drf{315,316,3161}
+    {py310,py311,py312,py313,py314}-django{52}-drf{3161}
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
-    3.12: py312,black,flake8,docs
+    3.12: py312
+    3.13: py313
+    3.14: py314,black,flake8,docs
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 commands = pytest {posargs}
 deps =
-    django32: Django==3.2
     django42: Django==4.2
-    django50: Django==5.0
-    drf312: djangorestframework==3.12
-    drf313: djangorestframework==3.13
-    drf314: djangorestframework==3.14
+    django52: Django==5.2
+    django60: Django==6.0
     drf315: djangorestframework==3.15
+    drf316: djangorestframework==3.16.0
+    drf3161: djangorestframework==3.16.1
 extras = test
 
 [testenv:black]
@@ -62,4 +60,4 @@ extras =
 [testenv:docs]
 commands = mkdocs build
 deps =
-    mkdocs>=1.5.3
+    mkdocs>=1.6.1

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     docs
     {py310,py311,py312}-django{42}-drf{315,316,3161}
     {py310,py311,py312,py313,py314}-django{52}-drf{3161}
+    {py312,py313,py314}-django{60}-drf{3161}
 
 [gh-actions]
 python =


### PR DESCRIPTION
With the imminent end-of-life of Django 4.2, I've updated the CI config to test against supported versions of Python/Django/DRF, and to drop official support for versions of those dependencies that are no longer getting updates.

## Changes

- Updated CI to run on Python 3.10-3.14
- Drop support for Python 3.8/3.9
- Updated CI to run on Django 5.2 and Django 6.0
- Drop support for Django 3.2 and Django 5.0, and older versions of Django Rest Framework
- Updated CI/dev dependencies to their latest versions
- Updated documentation and PyPI metadata